### PR TITLE
move stubbing code to seperate file

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,33 +1,6 @@
 #!/usr/bin/env node
 
 const repl = require('repl');
-const history = require('repl.history');
+const stubber = require('./stubber');
 const replInstance = repl.start({ prompt: 'async> ' });
-const originalEval = replInstance.eval;
-const rewrite = require('./rewrite');
-const os = require('os');
-const path = require('path');
-const historyFile = path.join(os.homedir(), '.async_repl_history');
-
-history(replInstance, historyFile);
-replInstance.eval = awaitingEval;
-
-function awaitingEval(cmd, context, filename, callback) {
-  try {
-    cmd = rewrite(cmd);
-  } catch (err) {
-    callback(err);
-  }
-  originalEval.call(this, cmd, context, filename, async function(err,value) {
-    if (err) {
-      callback.call(this, err, null);
-    } else {
-      try {
-        value = await value;
-        callback.call(this, err, value);
-      } catch (error) {
-        callback.call(this, error, null);
-      }
-    }
-  });
-}
+stubber(replInstance);

--- a/stubber.js
+++ b/stubber.js
@@ -1,0 +1,31 @@
+const history = require('repl.history');
+const os = require('os');
+const path = require('path');
+const historyFile = path.join(os.homedir(), '.async_repl_history');
+const rewrite = require('./rewrite');
+
+module.exports = function(repl){
+  const originalEval = repl.eval;
+  history(repl, historyFile);
+  repl.eval = awaitingEval;
+
+  function awaitingEval(cmd, context, filename, callback) {
+    try {
+      cmd = rewrite(cmd);
+    } catch (err) {
+      callback(err);
+    }
+    originalEval.call(this, cmd, context, filename, async function(err,value) {
+      if (err) {
+        callback.call(this, err, null);
+      } else {
+        try {
+          value = await value;
+          callback.call(this, err, value);
+        } catch (error) {
+          callback.call(this, error, null);
+        }
+      }
+    });
+  }
+}


### PR DESCRIPTION
Moved the code, that wraps original eval into a separate file, so that I can require it from another project that has its own REPL thing going on